### PR TITLE
Minor cleanup: prune `srand` and fix multiplication overflow panic in test

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -15,7 +15,6 @@ dependencies = [
 name = "drg-mission-gen"
 version = "0.1.0"
 dependencies = [
- "srand",
  "strum",
  "time",
 ]
@@ -25,12 +24,6 @@ name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
-
-[[package]]
-name = "lazy_static"
-version = "1.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "num-conv"
@@ -86,15 +79,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
-]
-
-[[package]]
-name = "srand"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf4b5c06dab00b9460e5d0a885a6bf891457f2e42b70f5a343d6b17382431b90"
-dependencies = [
- "lazy_static",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,6 +4,5 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-srand = "0.4.0"
 strum = { version = "0.26.3", features = ["derive"] }
 time = "0.3.36"

--- a/src/main.rs
+++ b/src/main.rs
@@ -584,10 +584,10 @@ mod test {
         let hour = now.hour() as u32;
         let minute = now.minute() as u32;
 
-        let seed = ((year * 0x2a90af)
-            ^ (month * 0x4f9ffb7)
-            ^ (day * 0x73387)
-            ^ (hour * 0x5b53f5)
+        let seed = ((year.wrapping_mul(0x2a90af))
+            ^ (month.wrapping_mul(0x4f9ffb7))
+            ^ (day.wrapping_mul(0x73387))
+            ^ (hour.wrapping_mul(0x5b53f5))
             ^ (minute / 30))
             % 100000;
         dbg!(seed);


### PR DESCRIPTION
`test_global_mission_seed` previously failed on my Windows machine because one of the multiplications in seed calculation panicked. This PR fixes that by using `wrapping_mul`.

`srand` is also pruned from dependencies because it was no longer needed, and was causing build failure on Windows.