### PR TITLE
Minor cleanups: fix typos and unused items in lib, minor formatting

### DIFF
--- a/drg_mission_gen_core/Cargo.toml
+++ b/drg_mission_gen_core/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "drg_mission_gen_core"
+edition.workspace = true
 license.workspace = true
 version.workspace = true
-edition.workspace = true
 
 [dependencies]
 pretty_assertions = "1.4.0"

--- a/drg_mission_gen_core/src/data.rs
+++ b/drg_mission_gen_core/src/data.rs
@@ -10,6 +10,7 @@ pub enum EPlanetZone {
     PZ_Zone03,
     PZ_Zone04,
 }
+
 impl EPlanetZone {
     pub fn get(&self) -> &'static UPlanetZone {
         match self {
@@ -118,6 +119,7 @@ pub enum EBiome {
     BIOME_AzureWeald,
     BIOME_HollowBough,
 }
+
 impl EBiome {
     pub fn get(&self) -> &'static UBiome {
         match self {
@@ -172,6 +174,7 @@ pub struct FRequiredMissionItem {
     pub duration: EMissionDuration,
     pub can_have_mutators: bool,
 }
+
 #[derive(Debug)]
 pub struct FMissionTemplateItem {
     pub mission_template: UMissionTemplate,
@@ -185,6 +188,7 @@ pub struct UMissionTemplate {
     pub deep_dive_objectives: &'static [EObjective],
     pub dna: &'static [EMissionDNA],
 }
+
 #[derive(Debug, Clone, Copy, PartialEq, VariantArray, Serialize, Deserialize)]
 pub enum EMissionTemplate {
     MissionType_Extraction,
@@ -197,6 +201,7 @@ pub enum EMissionTemplate {
     MissionType_Facility,
     MissionType_DeepScan,
 }
+
 impl EMissionTemplate {
     pub fn get(&self) -> &'static FMissionTemplateItem {
         match self {
@@ -662,6 +667,7 @@ pub struct FIRandRange {
     pub min: i32,
     pub max: i32,
 }
+
 impl FIRandRange {
     pub fn rand(&self, rand: &mut crate::FRandomStream) -> i32 {
         // TODO verify correctness
@@ -699,6 +705,7 @@ pub struct UDeepDiveSettings {
     pub mutators: &'static [EMissionMutator],
     pub warnings: &'static [EMissionWarning],
 }
+
 pub fn get_deep_dive_settings() -> &'static UDeepDiveSettings {
     &UDeepDiveSettings {
         mutators: &[
@@ -863,6 +870,7 @@ pub fn get_normal_template() -> &'static UDeepDiveTemplate {
         ],
     }
 }
+
 pub fn get_hard_template() -> &'static UDeepDiveTemplate {
     &UDeepDiveTemplate {
         mutator_count: FRandInterval {
@@ -1034,6 +1042,7 @@ pub enum EMissionWarning {
     WRN_Swarmagedon,
     WRN_RivalIncursion,
 }
+
 impl EObjective {
     pub fn is_banned_in_biome(self, biome: EBiome) -> bool {
         match self {
@@ -1046,6 +1055,7 @@ impl EObjective {
         .contains(&biome)
     }
 }
+
 impl EMissionMutator {
     pub fn is_banned_objective(self, obj: EObjective) -> bool {
         match self {
@@ -1055,6 +1065,7 @@ impl EMissionMutator {
         .contains(&obj)
     }
 }
+
 impl EMissionWarning {
     pub fn is_banned_objective(self, obj: EObjective) -> bool {
         match self {
@@ -1107,6 +1118,7 @@ pub enum ESeason {
     Season4,
     Season5,
 }
+
 impl ESeason {
     pub fn from_index(index: usize) -> Self {
         Self::VARIANTS[index]

--- a/drg_mission_gen_core/src/lib.rs
+++ b/drg_mission_gen_core/src/lib.rs
@@ -113,7 +113,7 @@ fn get_missions(seed: &FGlobalMissionSeed) {
     rand.mutate(); // TODO unused?
     let saved = rand.seed(); // surely there is some logical explanation here... forking rand stream?
     let rand_helper = (rand.get_fraction() * helpers.len() as f32) as usize;
-    rand.sed_seed(saved);
+    rand.set_seed(saved);
     dbg!(rand_helper);
 
     println!("{:X}", rand.seed());

--- a/drg_mission_gen_core/src/lib.rs
+++ b/drg_mission_gen_core/src/lib.rs
@@ -285,6 +285,7 @@ fn select_mutator(
 
     *rand.rand_item(&pool)
 }
+
 fn select_warning(
     warnings: &[EMissionWarning],
     mutator: Option<EMissionMutator>,

--- a/drg_mission_gen_core/src/rand.rs
+++ b/drg_mission_gen_core/src/rand.rs
@@ -13,7 +13,8 @@ impl FRandomStream {
     pub fn seed(&self) -> u32 {
         self.seed
     }
-    pub fn sed_seed(&mut self, seed: u32) {
+
+    pub fn set_seed(&mut self, seed: u32) {
         self.seed = seed
     }
     pub fn next_seed(&self) -> u32 {

--- a/drg_mission_gen_core/src/rand.rs
+++ b/drg_mission_gen_core/src/rand.rs
@@ -10,6 +10,7 @@ impl FRandomStream {
             seed,
         }
     }
+
     pub fn seed(&self) -> u32 {
         self.seed
     }
@@ -17,13 +18,16 @@ impl FRandomStream {
     pub fn set_seed(&mut self, seed: u32) {
         self.seed = seed
     }
+
     pub fn next_seed(&self) -> u32 {
         self.seed.wrapping_mul(0xbb38435).wrapping_add(0x3619636b)
     }
+
     pub fn mutate(&mut self) {
         self.seed = self.next_seed();
         //println!("MUTATE SEED {}", self.0);
     }
+
     pub fn get_fraction(&mut self) -> f32 {
         self.mutate();
         f32::from_bits(0x3f800000 | self.seed >> 9) - 1.0
@@ -36,17 +40,21 @@ impl FRandomStream {
             0
         }
     }
+
     pub fn rand_range(&mut self, min: i32, max: i32) -> i32 {
         min + self.rand_helper(max - min + 1)
     }
+
     pub fn rand_item<'a, T>(&mut self, slice: &'a [T]) -> &'a T {
         let i = self.rand_helper(slice.len() as i32) as usize;
         &slice[i]
     }
+
     pub fn rand_swap_remove<T>(&mut self, vec: &mut Vec<T>) -> T {
         let i = self.rand_helper(vec.len() as i32) as usize;
         vec.swap_remove(i)
     }
+
     pub fn rand_remove<T>(&mut self, vec: &mut Vec<T>) -> T {
         let i = self.rand_helper(vec.len() as i32) as usize;
         vec.remove(i)

--- a/drg_mission_gen_core/src/rand.rs
+++ b/drg_mission_gen_core/src/rand.rs
@@ -28,10 +28,7 @@ impl FRandomStream {
         self.mutate();
         f32::from_bits(0x3f800000 | self.seed >> 9) - 1.0
     }
-    pub fn get_unsigned_int(&mut self) -> u32 {
-        //self.mutate();
-        self.seed
-    }
+
     pub fn rand_helper(&mut self, max: i32) -> i32 {
         if max > 0 {
             (self.get_fraction() * (max as f32)) as i32

--- a/drg_mission_gen_seed_cli/Cargo.toml
+++ b/drg_mission_gen_seed_cli/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
+name = "drg_mission_gen_seed_cli"
 edition.workspace = true
 license.workspace = true
-name = "drg_mission_gen_seed_cli"
 version.workspace = true
 
 [dependencies]


### PR DESCRIPTION
- `drg_mission_gen_core`:
    - Rename `FRandomStream::sed_seed` -> `FRandomStream::set_seed`
    - Remove unused `FRandomStream::get_unsigned_int`
- Ensure newline between top-level items
- Format `Cargo.toml`s for consistency