### PR TITLE
Various fixes to the gsg endpoint cli

### DIFF
--- a/drg_mission_gen_gsg_endpoint_cli/src/cleaned_deep_dive.rs
+++ b/drg_mission_gen_gsg_endpoint_cli/src/cleaned_deep_dive.rs
@@ -132,7 +132,7 @@ impl PrimaryObjective {
             PrimaryObjective::PointExtraction => {
                 match (duration, complexity) {
                     (Duration::Normal, Complexity::Complex) => "7 Aquarqs",
-                    (Duration::Long, Complexity::Simple) => "10 Aquarqs",
+                    (Duration::Long, Complexity::Complex) => "10 Aquarqs",
                     (dur, comp) => unreachable!(
                         "unexpected point extraction duration/complexity combination: duration={dur:?}, complexity={comp:?}",
                     ),

--- a/drg_mission_gen_gsg_endpoint_cli/src/deep_dive_response.rs
+++ b/drg_mission_gen_gsg_endpoint_cli/src/deep_dive_response.rs
@@ -23,10 +23,10 @@ pub(crate) struct DeepDiveResponse {
     /// This may be a legacy seed used in older game versions. Does not seem to affect newer deep
     /// dives. Consider this unused.
     #[serde(rename = "Seed")]
-    _seed: i32,
+    _seed: i64,
     /// This is the seed used to generate both deep dive missions, which is the seed we're
     /// interested in.
-    pub(crate) seed_v2: i32,
+    pub(crate) seed_v2: i64,
     /// When does the dive expire?
     #[serde(rename = "ExpirationTime")]
     pub(crate) expiration_datetime: ExpirationDateTime,

--- a/drg_mission_gen_gsg_endpoint_cli/src/gsg_endpoint.rs
+++ b/drg_mission_gen_gsg_endpoint_cli/src/gsg_endpoint.rs
@@ -13,8 +13,8 @@ pub(crate) enum EndpointError {
         status_text: String,
         response_body: String,
     },
-    #[error("response failed to deserialize into expected `DeepDiveResponse` JSON format")]
-    FailedToDeserialize,
+    #[error("response failed to deserialize into expected `DeepDiveResponse` JSON format: {0}")]
+    FailedToDeserialize(std::io::Error),
     #[error("I/O error: {0}")]
     Io(#[from] std::io::Error),
     #[error("ureq error: {0}")]
@@ -39,5 +39,5 @@ pub(crate) fn query_gsg_deep_dive_endpoint() -> Result<DeepDiveResponse, Endpoin
 
     raw_response
         .into_json::<DeepDiveResponse>()
-        .map_err(|_| EndpointError::FailedToDeserialize)
+        .map_err(|e| EndpointError::FailedToDeserialize(e))
 }


### PR DESCRIPTION
- Apparently the seed can be larger than 32 bits. So use `i64` instead of `i32` for the response format. EDIT: seed is u32, but in transport I think I have seen negative seeds.
- Improve the error message for when the response fails to deserialize into our expected format.
- Fix an incorrect `(duration, complexity)` match for PE, where it should be `(Duration::Long, Complexity::Complex)` instead of `(Duration::Long, Complexity::Simple)`.