### PR TITLE
More endpoint fixes

### DIFF
--- a/drg_mission_gen_gsg_endpoint_cli/src/clean.rs
+++ b/drg_mission_gen_gsg_endpoint_cli/src/clean.rs
@@ -110,6 +110,7 @@ pub(crate) fn map_primary_objective(obj: &EObjective) -> Result<PrimaryObjective
         EObjective::OBJ_1st_PointExtraction => PrimaryObjective::PointExtraction,
         EObjective::OBJ_1st_Refinery => PrimaryObjective::Refinery,
         EObjective::OBJ_1st_Salvage => PrimaryObjective::Salvage,
+        EObjective::OBJ_Eliminate_Eggs => PrimaryObjective::Elimination,
         unexpected_obj => {
             return Err(CleanError::UnexpectedPrimaryObjective(
                 unexpected_obj.into(),

--- a/drg_mission_gen_gsg_endpoint_cli/src/cleaned_deep_dive.rs
+++ b/drg_mission_gen_gsg_endpoint_cli/src/cleaned_deep_dive.rs
@@ -63,6 +63,7 @@ pub(crate) enum PrimaryObjective {
     PointExtraction,
     Refinery,
     Salvage,
+    Elimination,
 }
 
 impl PrimaryObjective {
@@ -76,6 +77,7 @@ impl PrimaryObjective {
             PrimaryObjective::PointExtraction => "Point Extraction",
             PrimaryObjective::Refinery => "On-Site Refinery",
             PrimaryObjective::Salvage => "Salvage Operation",
+            PrimaryObjective::Elimination => "Elimination",
         }
     }
 
@@ -113,7 +115,7 @@ impl PrimaryObjective {
             },
             PrimaryObjective::IndustrialSabotage => {
                 match (duration, complexity) {
-                    (Duration::Short, Complexity::Simple | Complexity::Average) => "Industrial Sabotage",
+                    (Duration::Normal, Complexity::Simple | Complexity::Average) => "Industrial Sabotage",
                     (dur, comp) => unreachable!(
                         "unexpected industrial sabotage duration/complexity combination: duration={dur:?}, complexity={comp:?}",
                     ),
@@ -155,6 +157,15 @@ impl PrimaryObjective {
                     ),
                 }
             },
+            PrimaryObjective::Elimination => {
+                match (duration, complexity) {
+                    (Duration::Normal, Complexity::Average) => "Kill 2 dreadnoughts",
+                    (Duration::Long, Complexity::Complex) => "Kill 3 dreadnoughts",
+                    (dur, comp) => unreachable!(
+                        "unexpected elimination duration/complexity combination: duration={dur:?}, complexity={comp:?}",
+                    ),
+                }
+            }
         }
     }
 }
@@ -241,7 +252,7 @@ impl Warning {
             Warning::ShieldDisruption => "Shield Disruption",
             Warning::Parasites => "Parasites",
             Warning::Swarmageddon => "Swarmageddon",
-            Warning::RivalPresence => "RivalPresence",
+            Warning::RivalPresence => "Rival Presence",
         }
     }
 }

--- a/drg_mission_gen_gsg_endpoint_cli/src/formatters/discord.rs
+++ b/drg_mission_gen_gsg_endpoint_cli/src/formatters/discord.rs
@@ -1,5 +1,3 @@
-use std::iter;
-
 use time::OffsetDateTime;
 
 use crate::cleaned_deep_dive::{
@@ -116,6 +114,9 @@ fn format_primary_objective(
         }
         PrimaryObjective::Salvage => {
             format!(":molly: {}", obj.display_detailed(complexity, duration))
+        }
+        PrimaryObjective::Elimination => {
+            format!(":dreadegg: {}", obj.display_detailed(complexity, duration))
         }
     }
 }


### PR DESCRIPTION
- Add missing elimination objective (which was not named `1st_*` for whatever reason).
- Fix sabotage mission duration.
- Fix rival presence display missing space.